### PR TITLE
Fix race condition causing lost events

### DIFF
--- a/ClickEncoder.cpp
+++ b/ClickEncoder.cpp
@@ -213,7 +213,7 @@ int16_t ClickEncoder::getValue(void)
 ClickEncoder::Button ClickEncoder::getButton(void)
 {
   ClickEncoder::Button ret = button;
-  if (button != ClickEncoder::Held) {
+  if (button != ClickEncoder::Held && ret != ClickEncoder::Open) {
     button = ClickEncoder::Open; // reset
   }
   return ret;


### PR DESCRIPTION
If the ISR set the state of button after ret was set but before button
was set to open, the event was lost