### PR TITLE
Bugfix: Allow button on input digital 0 (disabled pin is -1)

### DIFF
--- a/ClickEncoder.cpp
+++ b/ClickEncoder.cpp
@@ -126,7 +126,7 @@ void ClickEncoder::service(void)
   // handle button
   //
 #ifndef WITHOUT_BUTTON
-  if (pinBTN > 0 // check button only, if a pin has been provided
+  if (pinBTN > -1 // check button only, if a pin has been provided
       && (now - lastButtonCheck) >= ENC_BUTTONINTERVAL) // checking button is sufficient every 10-30ms
   {
     lastButtonCheck = now;


### PR DESCRIPTION
Check for disabled pin with -1 instead of 0, allowing to use pin 0 for encoder switch.