### PR TITLE
Feature/specific active level

### DIFF
--- a/ClickEncoder.cpp
+++ b/ClickEncoder.cpp
@@ -127,7 +127,7 @@ void ClickEncoder::service(void)
   // handle button
   //
 #ifndef WITHOUT_BUTTON
-  if (pinBTN > 0 // check button only, if a pin has been provided
+  if (pinBTN > -1 // check button only, if a pin has been provided
       && (now - lastButtonCheck) >= ENC_BUTTONINTERVAL) // checking button is sufficient every 10-30ms
   {
     lastButtonCheck = now;

--- a/ClickEncoder.cpp
+++ b/ClickEncoder.cpp
@@ -43,22 +43,23 @@
 
 // ----------------------------------------------------------------------------
 
-ClickEncoder::ClickEncoder(uint8_t A, uint8_t B, uint8_t BTN, uint8_t stepsPerNotch, bool active)
+ClickEncoder::ClickEncoder(uint8_t A, uint8_t B, uint8_t BTN, uint8_t stepsPerNotch, bool coderActive, bool btnActive)
   : doubleClickEnabled(true), accelerationEnabled(true),
     delta(0), last(0), acceleration(0),
     button(Open), steps(stepsPerNotch),
-    pinA(A), pinB(B), pinBTN(BTN), pinsActive(active)
+    pinA(A), pinB(B), pinBTN(BTN), coderPinsActive(coderActive), btnPinActive(btnActive)
 {
-  uint8_t configType = (pinsActive == LOW) ? INPUT_PULLUP : INPUT;
-  pinMode(pinA, configType);
-  pinMode(pinB, configType);
-  pinMode(pinBTN, configType);
+  uint8_t coderType = (coderPinsActive == LOW) ? INPUT_PULLUP : INPUT;
+  pinMode(pinA, coderType);
+  pinMode(pinB, coderType);
+  uint8_t btnType = (btnPinActive == LOW) ? INPUT_PULLUP : INPUT;
+  pinMode(pinBTN, btnType);
 
-  if (digitalRead(pinA) == pinsActive) {
+  if (digitalRead(pinA) == coderPinsActive) {
     last = 3;
   }
 
-  if (digitalRead(pinB) == pinsActive) {
+  if (digitalRead(pinB) == coderPinsActive) {
     last ^=1;
   }
 }
@@ -81,11 +82,11 @@ void ClickEncoder::service(void)
 #if ENC_DECODER == ENC_FLAKY
   last = (last << 2) & 0x0F;
 
-  if (digitalRead(pinA) == pinsActive) {
+  if (digitalRead(pinA) == coderPinsActive) {
     last |= 2;
   }
 
-  if (digitalRead(pinB) == pinsActive) {
+  if (digitalRead(pinB) == coderPinsActive) {
     last |= 1;
   }
 
@@ -97,11 +98,11 @@ void ClickEncoder::service(void)
 #elif ENC_DECODER == ENC_NORMAL
   int8_t curr = 0;
 
-  if (digitalRead(pinA) == pinsActive) {
+  if (digitalRead(pinA) == coderPinsActive) {
     curr = 3;
   }
 
-  if (digitalRead(pinB) == pinsActive) {
+  if (digitalRead(pinB) == coderPinsActive) {
     curr ^= 1;
   }
 
@@ -131,14 +132,14 @@ void ClickEncoder::service(void)
   {
     lastButtonCheck = now;
 
-    if (digitalRead(pinBTN) == pinsActive) { // key is down
+    if (digitalRead(pinBTN) == btnPinActive) { // key is down
       keyDownTicks++;
       if (keyDownTicks > (ENC_HOLDTIME / ENC_BUTTONINTERVAL)) {
         button = Held;
       }
     }
 
-    if (digitalRead(pinBTN) == !pinsActive) { // key is now up
+    if (digitalRead(pinBTN) == !btnPinActive) { // key is now up
       if (keyDownTicks /*> ENC_BUTTONINTERVAL*/) {
         if (button == Held) {
           button = Released;

--- a/ClickEncoder.h
+++ b/ClickEncoder.h
@@ -57,7 +57,7 @@ public:
 
 public:
   ClickEncoder(uint8_t A, uint8_t B, uint8_t BTN = -1,
-               uint8_t stepsPerNotch = 1, bool active = LOW);
+               uint8_t stepsPerNotch = 1, bool coderActive = LOW, bool btnActive = HIGH);
 
   void service(void);
   int16_t getValue(void);
@@ -98,7 +98,8 @@ private:
   const uint8_t pinA;
   const uint8_t pinB;
   const uint8_t pinBTN;
-  const bool pinsActive;
+  const bool coderPinsActive;
+  const bool btnPinActive;
   volatile int16_t delta;
   volatile int16_t last;
   uint8_t steps;

--- a/ClickEncoder.h
+++ b/ClickEncoder.h
@@ -57,7 +57,7 @@ public:
 
 public:
   ClickEncoder(uint8_t A, uint8_t B, uint8_t BTN = -1,
-               uint8_t stepsPerNotch = 1, bool coderActive = LOW, bool btnActive = HIGH);
+               uint8_t stepsPerNotch = 1, bool coderActive = LOW, bool btnActive = LOW);
 
   void service(void);
   int16_t getValue(void);


### PR DESCRIPTION
Allow to set a different activation level for encoder and button (button for illuminated encoder may be linked with common-anode LED, but LOW may be prefered for encoder input).