### PR TITLE
Fix initializer list order for newer compilers

### DIFF
--- a/ClickEncoder.cpp
+++ b/ClickEncoder.cpp
@@ -43,11 +43,22 @@
 
 // ----------------------------------------------------------------------------
 
-ClickEncoder::ClickEncoder(uint8_t A, uint8_t B, uint8_t BTN, uint8_t stepsPerNotch, bool active)
-  : doubleClickEnabled(true), accelerationEnabled(true),
-    delta(0), last(0), acceleration(0),
-    button(Open), steps(stepsPerNotch),
-    pinA(A), pinB(B), pinBTN(BTN), pinsActive(active)
+ClickEncoder::ClickEncoder(
+    uint8_t A,
+    uint8_t B,
+    uint8_t BTN,
+    uint8_t stepsPerNotch,
+    bool active) : pinA(A),
+                   pinB(B),
+                   pinBTN(BTN),
+                   steps(stepsPerNotch),
+                   pinsActive(active),
+                   doubleClickEnabled(true),
+                   accelerationEnabled(true),
+                   delta(0),
+                   last(0),
+                   acceleration(0),
+                   button(Open)
 {
   uint8_t configType = (pinsActive == LOW) ? INPUT_PULLUP : INPUT;
   pinMode(pinA, configType);

--- a/ClickEncoder.h
+++ b/ClickEncoder.h
@@ -95,24 +95,26 @@ public:
   }
 
 private:
-  const uint8_t pinA;
-  const uint8_t pinB;
-  const uint8_t pinBTN;
-  const bool pinsActive;
-  volatile int16_t delta;
-  volatile int16_t last;
-  uint8_t steps;
-  volatile uint16_t acceleration;
-  bool accelerationEnabled;
+    const uint8_t pinA;
+    const uint8_t pinB;
+    const uint8_t pinBTN;
+    uint8_t steps;
+    const bool pinsActive;
+#ifndef WITHOUT_BUTTON
+    bool doubleClickEnabled;
+#endif
+    bool accelerationEnabled;
+    volatile int16_t delta;
+    volatile int16_t last;
+    volatile uint16_t acceleration;
 #if ENC_DECODER != ENC_NORMAL
-  static const int8_t table[16];
+    static const int8_t table[16];
 #endif
 #ifndef WITHOUT_BUTTON
-  volatile Button button;
-  bool doubleClickEnabled;
-  uint16_t keyDownTicks = 0;
-  uint8_t doubleClickTicks = 0;
-  unsigned long lastButtonCheck = 0;
+    volatile Button button;
+    uint16_t keyDownTicks = 0;
+    uint8_t doubleClickTicks = 0;
+    unsigned long lastButtonCheck = 0;
 #endif
 };
 

--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/0xPIT/encoder.git"
+    "url": "https://github.com/Schallbert/encoder.git"
   },
   "frameworks": "arduino",
   "platforms": "atmelavr"


### PR DESCRIPTION
fix compiler error about constructor's initializer list not being in order.
Updated the platformio lib path (used it in my project) but as I don't want to take credit for this lib, of course you're free to change it back.